### PR TITLE
[FEATURE] Fix OOV in word2vec

### DIFF
--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -1,3 +1,12 @@
+v0.0.7:
+    1. add BERT and pretrained model (luna_bert)
+    2. speed up the process in sif
+    3. handling OOV in word2vec
+    4. add English tutorials
+    5. add api docs and prettify tutorials
+    6. fix the np.error in gensim_vec.W2V.infer_vector
+    7. fix the parameters lost in tokenization
+
 v0.0.6:
     1. dev: add half-pretrained rnn model
     2. important!!!: rename TextTokenizer to PureTextTokenizer, and add a new tokenizer named TextTokenizer (the two have similar but not the same behaviours).

--- a/EduNLP/Vector/gensim_vec.py
+++ b/EduNLP/Vector/gensim_vec.py
@@ -62,7 +62,8 @@ class W2V(Vector):
             yield self[word]
 
     def __getitem__(self, item):
-        return self.wv[item] if item not in self.constants else np.zeros((self.vector_size,))
+        index = self.key_to_index(item)
+        return self.wv[item] if index not in self.constants.values() else np.zeros((self.vector_size,))
 
     def infer_vector(self, items, agg="mean", *args, **kwargs) -> np.ndarray:
         token_vectors = self.infer_tokens(items, *args, **kwargs)

--- a/tests/test_vec/test_vec.py
+++ b/tests/test_vec/test_vec.py
@@ -86,6 +86,7 @@ def test_w2v(stem_tokens, tmpdir, method, binary):
     assert w2v.vectors.shape == (len(w2v.wv.vectors) + len(w2v.constants), w2v.vector_size)
     assert w2v.key_to_index("[UNK]") == 0
     assert w2v.key_to_index("OOV") == 0
+    assert np.array_equal(w2v["OOV"], np.zeros((10,)))
 
     t2v = T2V("w2v", filepath=filepath, method=method, binary=binary)
     assert len(t2v(stem_tokens[:1])[0]) == t2v.vector_size


### PR DESCRIPTION
Thanks for sending a pull request! 
Please make sure you click the link above to view the [contribution guidelines](../CONTRIBUTE.md), 
then fill out the blanks below.

## Description ##
Use UNK to fix the OOV problem in word2vec.


### What does this implement/fix? Explain your changes.
Before using word2vec to infer tokens, check  wheather the word is  in the vocabulary.


#### Pull request type
- [ ] [DATASET] Add a new dataset
- [ ] [BUGFIX] Bugfix
- [x] [FEATURE] New feature (non-breaking change which adds functionality)
- [ ] [BREAKING] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] [STYLE] Code style update (formatting, renaming)
- [ ] [REFACTOR] Refactoring (no functional changes, no api changes)
- [ ] [BUILD] Build related changes
- [ ] [DOC] Documentation content changes
- [ ] [OTHER] Other (please describe): 


#### Changes
Feat1, use UNK to fix the OOV problem in word2vec.

### Does this close any currently open issues?
#101 

### Any relevant logs, error output, etc?
Before
```python
import numpy as np
from EduNLP.Tokenizer import get_tokenizer
from EduNLP.Vector import T2V
print(items)
tokenzier = get_tokenizer("pure_text")
token_items = tokenzier(items)
# ['OOV', '霜飔曈', '曚', '菡萏', '叆', '叇']

path = "./w2v/general_literal_300/general_literal_300.kv"
t2v = T2V('w2v',filepath=path)

t2v.infer_tokens(token_items)
# KeyError: "Key 'OOV' not present"
```
After
```python
t2v.i2v.key_to_index("OOV")
# 0
np.array_equal(t2v.i2v["OOV"], np.zeros((300,)))
# True
```


## Checklist ##
Before you submit a pull request, please make sure you have to following:

### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [FEATURE], [BREAKING], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage and al tests passing
- [x] Code is well-documented (extended the README / documentation, if necessary)
- [x] If this PR is your first one, add your name and github account to [AUTHORS.md](../AUTHORS.md)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
