### PR TITLE
[BUGFIX] fix the error for cpu and cuda

### DIFF
--- a/EduNLP/ModelZoo/rnn/rnn.py
+++ b/EduNLP/ModelZoo/rnn/rnn.py
@@ -96,9 +96,9 @@ class LM(nn.Module):
         """
         seq = self.embedding(seq_idx)
         pack = pack_padded_sequence(seq, seq_len, batch_first=True)
-        h0 = torch.zeros(self.num_layers, seq.shape[0], self.hidden_size)
+        h0 = torch.zeros(self.num_layers, seq.shape[0], self.hidden_size).to(seq_idx.device)
         if self.c is True:
-            c0 = torch.zeros(self.num_layers, seq.shape[0], self.hidden_size)
+            c0 = torch.zeros(self.num_layers, seq.shape[0], self.hidden_size).to(seq_idx.device)
             output, (hn, _) = self.rnn(pack, (h0, c0))
         else:
             output, hn = self.rnn(pack, h0)

--- a/EduNLP/ModelZoo/utils/device.py
+++ b/EduNLP/ModelZoo/utils/device.py
@@ -8,8 +8,6 @@ from torch.nn import DataParallel
 def set_device(_net, ctx, *args, **kwargs):  # pragma: no cover
     """code from longling v1.3.26"""
     if ctx == "cpu":
-        if not isinstance(_net, DataParallel):
-            _net = DataParallel(_net)
         return _net.cpu()
     elif any(map(lambda x: x in ctx, ["cuda", "gpu"])):
         if not torch.cuda.is_available():
@@ -24,7 +22,7 @@ def set_device(_net, ctx, *args, **kwargs):  # pragma: no cover
                 device_ids = [int(i) for i in device_ids.strip().split(",")]
                 try:
                     if not isinstance(_net, DataParallel):
-                        return DataParallel(_net, device_ids).cuda
+                        return DataParallel(_net, device_ids).cuda()
                     return _net.cuda(device_ids)
                 except AssertionError as e:
                     logging.error(device_ids)

--- a/EduNLP/ModelZoo/utils/device.py
+++ b/EduNLP/ModelZoo/utils/device.py
@@ -12,7 +12,7 @@ def set_device(_net, ctx, *args, **kwargs):  # pragma: no cover
     elif any(map(lambda x: x in ctx, ["cuda", "gpu"])):
         if not torch.cuda.is_available():
             try:
-                torch.ones((1,), device=torch.device("cuda: 0"))
+                torch.ones((1,), device=torch.device("cuda:0"))
             except AssertionError as e:
                 raise TypeError("no cuda detected, noly cpu is supported, the detailed error msg:%s" % str(e))
         if torch.cuda.device_count() >= 1:


### PR DESCRIPTION
Thanks for sending a pull request! 
Please make sure you click the link above to view the [contribution guidelines](../CONTRIBUTE.md), 
then fill out the blanks below.

## Description ##

### What does this implement/fix? Explain your changes.
1. fix the DataParallel error for cpu
2. fix the cuda error in rnn


#### Pull request type
- [ ] [DATASET] Add a new dataset
- [x] [BUGFIX] Bugfix
- [ ] [FEATURE] New feature (non-breaking change which adds functionality)
- [ ] [BREAKING] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] [STYLE] Code style update (formatting, renaming)
- [ ] [REFACTOR] Refactoring (no functional changes, no api changes)
- [ ] [BUILD] Build related changes
- [ ] [DOC] Documentation content changes
- [ ] [OTHER] Other (please describe): 


#### Changes
1. fix the DataParallel error for cpu
2. fix the cuda error in rnn

### Does this close any currently open issues?
#109 

### Any relevant logs, error output, etc?
Error 1:：when use cpu to test rnn
```
def test_rnn(stem_tokens, tmpdir):
method = "sg"
filepath_prefix = str(tmpdir.mkdir(method).join("stem_tf_"))
filepath = train_vector(
stem_tokens,
filepath_prefix,
10,
method=method,
train_params=dict(min_count=0)
)
w2v = W2V(filepath, method=method)
with pytest.raises(TypeError):
RNNModel("Error", w2v, 20)
for rnn_type in ["Rnn", "lstm", "GRU"]:
rnn = RNNModel(rnn_type, w2v, 20, device="cpu")
# print('DEBUG', next(rnn.rnn.parameters()).device)
tokens = rnn.infer_tokens(stem_tokens[:1])

tests/test_vec/test_vec.py:152:

EduNLP/Vector/rnn/rnn.py:81: in infer_tokens
tokens = self(items, **kwargs)[0]
EduNLP/Vector/rnn/rnn.py:67: in call
tokens, item = self.rnn(torch.LongTensor(seq_idx), torch.LongTensor(seq_len))
../../.local/lib/python3.6/site-packages/torch/nn/modules/module.py:1051: in _call_impl
return forward_call(*input, **kwargs)

self = DataParallel(
(module): LM(
(embedding): Embedding(96, 10)
(rnn): RNN(10, 20)
)
)
inputs = (tensor([[28, 34, 2, 8, 2, 37, 2, 3, 4, 5, 10, 3, 2, 10, 3, 39, 3, 13,
6, 2, 8, 13, 10, 3, 6, 3, 6, 3, 6, 3, 40, 6, 2, 42, 2, 8]]), tensor([36]))
kwargs = {}
t = Parameter containing:
tensor([[-1.3489e+00, 1.0146e+00, -6.5648e-01, 1.3789e+00, 8.4049e-01,
-4.5570e-01, ...01, 2.2516e+00,
-9.9800e-01, -1.1827e+00, 1.8549e+00, 5.5470e-01, -6.5661e-01]],
requires_grad=True)

def forward(self, *inputs, **kwargs):
with torch.autograd.profiler.record_function("DataParallel.forward"):
if not self.device_ids:
return self.module(*inputs, **kwargs)
for t in chain(self.module.parameters(), self.module.buffers()):
if t.device != self.src_device_obj:
raise RuntimeError("module must have its parameters and buffers "
"on device {} (device_ids[0]) but found one of "
"them on device: {}".format(self.src_device_obj, t.device))
E RuntimeError: module must have its parameters and buffers on device cuda:0 (device_ids[0]) but found one of them on device: cpu
../../.local/lib/python3.6/site-packages/torch/nn/parallel/data_parallel.py:156: RuntimeError
```
Error 2：when use cuda to test rnn
```
stem_tokens = [['已知', '集合', 'mathord', '=', 'mathord', '\\mid', ...], ['复数', 'mathord', '=', 'textord', '+', 'textord', ...], ['埃及',...hord', ...], ['某校', '课外', '学习', '小组', '研究', '作物', ...], ['已知', '圆', 'mathord', 'textord', '{ }', '\\supsub', ...], ...]
tmpdir = local('/tmp/pytest-of-qlh/pytest-24/test_rnn0')

    def test_rnn(stem_tokens, tmpdir):
        method = "sg"
        filepath_prefix = str(tmpdir.mkdir(method).join("stem_tf_"))
        filepath = train_vector(
            stem_tokens,
            filepath_prefix,
            10,
            method=method,
            train_params=dict(min_count=0)
        )
        w2v = W2V(filepath, method=method)
    
        with pytest.raises(TypeError):
            RNNModel("Error", w2v, 20)
    
        for rnn_type in ["ElMo", "Rnn", "lstm", "GRU"]:
            rnn = RNNModel(rnn_type, w2v, 20, device="cuda")
    
>           tokens = rnn.infer_tokens(stem_tokens[:1])

tests/test_vec/test_vec.py:152: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
EduNLP/Vector/rnn/rnn.py:81: in infer_tokens
    tokens = self(items, **kwargs)[0]
EduNLP/Vector/rnn/rnn.py:67: in __call__
    tokens, item = self.rnn(torch.LongTensor(seq_idx), torch.LongTensor(seq_len))
../anaconda3/envs/dev/lib/python3.6/site-packages/torch/nn/modules/module.py:722: in _call_impl
    result = self.forward(*input, **kwargs)
../anaconda3/envs/dev/lib/python3.6/site-packages/torch/nn/parallel/data_parallel.py:155: in forward
    outputs = self.parallel_apply(replicas, inputs, kwargs)
../anaconda3/envs/dev/lib/python3.6/site-packages/torch/nn/parallel/data_parallel.py:165: in parallel_apply
    return parallel_apply(replicas, inputs, kwargs, self.device_ids[:len(replicas)])
../anaconda3/envs/dev/lib/python3.6/site-packages/torch/nn/parallel/parallel_apply.py:85: in parallel_apply
    output.reraise()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <torch._utils.ExceptionWrapper object at 0x7f37a00531d0>

    def reraise(self):
        r"""Reraises the wrapped exception in the current thread"""
        # Format a message such as: "Caught ValueError in DataLoader worker
        # process 2. Original Traceback:", followed by the traceback.
        msg = "Caught {} {}.\nOriginal {}".format(
            self.exc_type.__name__, self.where, self.exc_msg)
        if self.exc_type == KeyError:
            # KeyError calls repr() on its argument (usually a dict key). This
            # makes stack traces unreadable. It will not be changed in Python
            # (https://bugs.python.org/issue2651), so we work around it.
            msg = KeyErrorMessage(msg)
>       raise self.exc_type(msg)
E       RuntimeError: Caught RuntimeError in replica 0 on device 0.
E       Original Traceback (most recent call last):
E         File "/home/qlh/anaconda3/envs/dev/lib/python3.6/site-packages/torch/nn/parallel/parallel_apply.py", line 60, in _worker
E           output = module(*input, **kwargs)
E         File "/home/qlh/anaconda3/envs/dev/lib/python3.6/site-packages/torch/nn/modules/module.py", line 722, in _call_impl
E           result = self.forward(*input, **kwargs)
E         File "/home/qlh/EduNLP/EduNLP/ModelZoo/rnn/rnn.py", line 102, in forward
E           output, (hn, _) = self.rnn(pack, (h0, c0))
E         File "/home/qlh/anaconda3/envs/dev/lib/python3.6/site-packages/torch/nn/modules/module.py", line 722, in _call_impl
E           result = self.forward(*input, **kwargs)
E         File "/home/qlh/anaconda3/envs/dev/lib/python3.6/site-packages/torch/nn/modules/rnn.py", line 580, in forward
E           self.num_layers, self.dropout, self.training, self.bidirectional)
E       RuntimeError: Input and hidden tensors are not at the same device, found input tensor at cuda:0 and hidden tensor at cpu

../anaconda3/envs/dev/lib/python3.6/site-packages/torch/_utils.py:395: RuntimeError
```

## Checklist ##
Before you submit a pull request, please make sure you have to following:

### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [FEATURE], [BREAKING], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage and al tests passing
- [x] Code is well-documented (extended the README / documentation, if necessary)
- [x] If this PR is your first one, add your name and github account to [AUTHORS.md](../AUTHORS.md)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
