### PR TITLE
[BUGFIX] fix the bug of counting lines in Windows

### DIFF
--- a/EduNLP/Pretrain/quesnet_vec.py
+++ b/EduNLP/Pretrain/quesnet_vec.py
@@ -358,10 +358,9 @@ def clip(v, low, high):
 class Lines:
     def __init__(self, filename, skip=0, preserve_newline=False):
         self.filename = filename
-        with open(filename):
-            pass
-        output = subprocess.check_output(('wc -l ' + filename).split())
-        self.length = int(output.split()[0]) - skip
+        with open(filename) as f:
+            self.length = len(f.readlines()) - skip
+        assert self.length > 0, f'{filename} is empty. Or file length is less than skip length.'
         self.skip = skip
         self.preserve_newline = preserve_newline
 
@@ -410,7 +409,8 @@ class QuestionLoader:
                  content_key=lambda x: x['ques_content'],
                  meta_key=lambda x: x['know_name'],
                  answer_key=lambda x: x['ques_answer'],
-                 option_key=lambda x: x['ques_options']
+                 option_key=lambda x: x['ques_options'],
+                 skip=0
                  ):
         """ Read question file as data list. Same behavior on same file.
 
@@ -431,10 +431,12 @@ class QuestionLoader:
             by default lambda x:x['ques_answer']
         option_key: function, optional
             by default lambda x:x['ques_options']
+        skip: int, optional
+            skip the first several lines, by default 0
         """
         self.range = None
         self.ques = Lines(ques_file, skip=1)
-        self.range = range or slice(0, len(self), 1)
+        self.range = range or slice(0, len(self), skip)
         self.img_dir = tokenizer.img_dir
         self.labels = []
         self.stoi = tokenizer.stoi


### PR DESCRIPTION
Thanks for sending a pull request! 
Please make sure you click the link above to view the [contribution guidelines](../CONTRIBUTE.md), 
then fill out the blanks below.

## Description ##
Fix the bug of counting lines in `class Lines()`. 
The origin way to count lines
 ``` Python
output = subprocess.check_output(('wc -l ' + filename).split())
self.length = int(output.split()[0]) - skip
```
cannot work in Windows.

### What does this implement/fix? Explain your changes.
Use `f.readlines()` to count lines instead of `wc -l`

#### Pull request type
- [ ] [DATASET] Add a new dataset
- [x] [BUGFIX] Bugfix
- [ ] [FEATURE] New feature (non-breaking change which adds functionality)
- [ ] [BREAKING] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] [STYLE] Code style update (formatting, renaming)
- [ ] [REFACTOR] Refactoring (no functional changes, no api changes)
- [ ] [BUILD] Build related changes
- [ ] [DOC] Documentation content changes
- [ ] [OTHER] Other (please describe): 


#### Changes

Fix the bug of counting lines in `class Lines()`

### Does this close any currently open issues?
no

### Any relevant logs, error output, etc?
...

## Checklist ##
Before you submit a pull request, please make sure you have to following:

### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [FEATURE], [BREAKING], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage and al tests passing
- [x] Code is well-documented (extended the README / documentation, if necessary)
- [x] If this PR is your first one, add your name and github account to [AUTHORS.md](../AUTHORS.md)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
